### PR TITLE
change MySQL/MariaDB SQL statement for changeColumnType method

### DIFF
--- a/packages/orm/angel_migration_runner/lib/src/mariadb/table.dart
+++ b/packages/orm/angel_migration_runner/lib/src/mariadb/table.dart
@@ -153,7 +153,7 @@ class MariaDbAlterTable extends Table implements MutableTable {
   @override
   void changeColumnType(String name, ColumnType type, {int length = 256}) {
     _stack.add(
-        'ALTER COLUMN $name TYPE ${MariaDbGenerator.columnType(MigrationColumn(type, length: length))}');
+        'MODIFY $name ${MariaDbGenerator.columnType(MigrationColumn(type, length: length))}');
   }
 
   @override

--- a/packages/orm/angel_migration_runner/lib/src/mysql/table.dart
+++ b/packages/orm/angel_migration_runner/lib/src/mysql/table.dart
@@ -152,7 +152,7 @@ class MysqlAlterTable extends Table implements MutableTable {
   @override
   void changeColumnType(String name, ColumnType type, {int length = 256}) {
     _stack.add(
-        'ALTER COLUMN $name TYPE ${MySqlGenerator.columnType(MigrationColumn(type, length: length))}');
+        'MODIFY $name ${MySqlGenerator.columnType(MigrationColumn(type, length: length))}');
   }
 
   @override


### PR DESCRIPTION
Hi, we found a bug in the package angel_migration_runner on the method changeColumnType

this method generate a SQL statement like this
```
ALTER TABLE [table] ALTER COLUMN [column] TYPE varchar(32);
```
this statement is not working for MariaDB or MySQL, the correct SQL statement is
```
ALTER TABLE [table] MODIFY [column] varchar(32);
```

