### PR TITLE
add/fix table index setting

### DIFF
--- a/packages/orm/angel_migration/lib/src/column.dart
+++ b/packages/orm/angel_migration/lib/src/column.dart
@@ -21,7 +21,7 @@ class MigrationColumn extends Column {
   MigrationColumn(ColumnType type,
       {bool isNullable = true,
       super.length,
-      IndexType indexType = IndexType.standardIndex,
+      IndexType indexType = IndexType.none,
       dynamic defaultValue})
       : super(type: type, isNullable: isNullable, defaultValue: defaultValue) {
     _nullable = isNullable;

--- a/packages/orm/angel_migration_runner/lib/src/mariadb/table.dart
+++ b/packages/orm/angel_migration_runner/lib/src/mariadb/table.dart
@@ -57,6 +57,14 @@ abstract class MariaDbGenerator {
     return buf.toString();
   }
 
+  static String? compileIndex(String name, MigrationColumn column) {
+    if (column.indexType == IndexType.standardIndex) {
+      return ' INDEX(`$name`)';
+    }
+
+    return null;
+  }
+
   static String compileReference(MigrationColumnReference ref) {
     var buf = StringBuffer('REFERENCES ${ref.foreignTable}(${ref.foreignKey})');
     if (ref.behavior != null) buf.write(' ${ref.behavior!}');
@@ -79,6 +87,7 @@ class MariaDbTable extends Table {
 
   void compile(StringBuffer buf, int indent) {
     var i = 0;
+    List indexBuf = [];
 
     _columns.forEach((name, column) {
       var col = MariaDbGenerator.compileColumn(column);
@@ -89,7 +98,16 @@ class MariaDbTable extends Table {
       }
 
       buf.write('$name $col');
+
+      var index = MariaDbGenerator.compileIndex(name, column);
+      if (index != null) indexBuf.add(index);
     });
+
+    if (indexBuf.isNotEmpty) {
+      for (var i = 0; i < indexBuf.length; i++) {
+        buf.write(',\n${indexBuf[$1]}');
+      }
+    }
   }
 }
 

--- a/packages/orm/angel_migration_runner/lib/src/mysql/table.dart
+++ b/packages/orm/angel_migration_runner/lib/src/mysql/table.dart
@@ -56,6 +56,14 @@ abstract class MySqlGenerator {
     return buf.toString();
   }
 
+  static String? compileIndex(String name, MigrationColumn column) {
+    if (column.indexType == IndexType.standardIndex) {
+      return ' INDEX(`$name`)';
+    }
+
+    return null;
+  }
+
   static String compileReference(MigrationColumnReference ref) {
     var buf = StringBuffer('REFERENCES ${ref.foreignTable}(${ref.foreignKey})');
     if (ref.behavior != null) buf.write(' ${ref.behavior!}');
@@ -78,6 +86,7 @@ class MysqlTable extends Table {
 
   void compile(StringBuffer buf, int indent) {
     var i = 0;
+    List indexBuf = [];
 
     _columns.forEach((name, column) {
       var col = MySqlGenerator.compileColumn(column);
@@ -88,7 +97,16 @@ class MysqlTable extends Table {
       }
 
       buf.write('$name $col');
+
+      var index = MySqlGenerator.compileIndex(name, column);
+      if (index != null) indexBuf.add(index);
     });
+
+    if (indexBuf.isNotEmpty) {
+      for (var i = 0; i < indexBuf.length; i++) {
+        buf.write(',\n${indexBuf[$1]}');
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Hi,

in the column you can set a `indexType = IndexType.standardIndex` but is had no effect right now, i have implement it for MySQL and MariaDB as a first suggestion, as a final or extra solution i think we need a separate way to add indexes with the **Orm** Annotation like 
```
@Orm(
  tableName: 'user',
  generateMigrations: true,
  indexes: [
    @Index(name="search_idx", columns=["name", "email"])
  ]
)
```

i hope it is ok that we start with a MySQL/MariaDB solution :-)