### PR TITLE
index handling for after table

### DIFF
--- a/packages/orm/angel_migration/lib/src/table.dart
+++ b/packages/orm/angel_migration/lib/src/table.dart
@@ -1,4 +1,5 @@
 import 'package:angel3_orm/angel3_orm.dart';
+
 import 'column.dart';
 
 abstract class Table {
@@ -49,4 +50,7 @@ abstract class MutableTable extends Table {
   void changeColumnType(String name, ColumnType type);
   void dropNotNull(String name);
   void setNotNull(String name);
+  void addIndex(String name, List<String> columns, IndexType type);
+  void dropIndex(String name);
+  void dropPrimaryIndex();
 }

--- a/packages/orm/angel_migration_runner/lib/src/mariadb/table.dart
+++ b/packages/orm/angel_migration_runner/lib/src/mariadb/table.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
-import 'package:angel3_orm/angel3_orm.dart';
+
 import 'package:angel3_migration/angel3_migration.dart';
+import 'package:angel3_orm/angel3_orm.dart';
 import 'package:charcode/ascii.dart';
 
 abstract class MariaDbGenerator {
@@ -169,5 +170,38 @@ class MariaDbAlterTable extends Table implements MutableTable {
   @override
   void rename(String newName) {
     _stack.add('RENAME TO $newName');
+  }
+
+  @override
+  void addIndex(String name, List<String> columns, IndexType type) {
+    String indexType = '';
+
+    switch (type) {
+      case IndexType.primaryKey:
+        indexType = 'PRIMARY KEY';
+        break;
+      case IndexType.unique:
+        indexType = 'UNIQUE INDEX IF NOT EXISTS `$name`';
+        break;
+      case IndexType.standardIndex:
+      case IndexType.none:
+        indexType = 'INDEX IF NOT EXISTS `$name`';
+        break;
+    }
+
+    // mask the column names, is more safety
+    columns.map((column) => '`$column`');
+
+    _stack.add('ADD $indexType (${columns.join(',')})');
+  }
+
+  @override
+  void dropIndex(String name) {
+    _stack.add('DROP INDEX IF EXISTS `$name`');
+  }
+
+  @override
+  void dropPrimaryIndex() {
+    _stack.add('DROP PRIMARY KEY');
   }
 }

--- a/packages/orm/angel_migration_runner/lib/src/mysql/table.dart
+++ b/packages/orm/angel_migration_runner/lib/src/mysql/table.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
-import 'package:angel3_orm/angel3_orm.dart';
+
 import 'package:angel3_migration/angel3_migration.dart';
+import 'package:angel3_orm/angel3_orm.dart';
 import 'package:charcode/ascii.dart';
 
 abstract class MySqlGenerator {
@@ -168,5 +169,38 @@ class MysqlAlterTable extends Table implements MutableTable {
   @override
   void rename(String newName) {
     _stack.add('RENAME TO $newName');
+  }
+
+  @override
+  void addIndex(String name, List<String> columns, IndexType type) {
+    String indexType = '';
+
+    switch (type) {
+      case IndexType.primaryKey:
+        indexType = 'PRIMARY KEY';
+        break;
+      case IndexType.unique:
+        indexType = 'UNIQUE INDEX `$name`';
+        break;
+      case IndexType.standardIndex:
+      case IndexType.none:
+        indexType = 'INDEX `$name`';
+        break;
+    }
+
+    // mask the column names, is more safety
+    columns.map((column) => '`$column`');
+
+    _stack.add('ADD $indexType (${columns.join(',')})');
+  }
+
+  @override
+  void dropIndex(String name) {
+    _stack.add('DROP INDEX `$name`');
+  }
+
+  @override
+  void dropPrimaryIndex() {
+    _stack.add('DROP PRIMARY KEY');
   }
 }

--- a/packages/orm/angel_migration_runner/lib/src/postgres/table.dart
+++ b/packages/orm/angel_migration_runner/lib/src/postgres/table.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
-import 'package:angel3_orm/angel3_orm.dart';
+
 import 'package:angel3_migration/angel3_migration.dart';
+import 'package:angel3_orm/angel3_orm.dart';
 import 'package:charcode/ascii.dart';
 
 abstract class PostgresGenerator {
@@ -164,5 +165,38 @@ class PostgresAlterTable extends Table implements MutableTable {
   @override
   void rename(String newName) {
     _stack.add('RENAME TO "$newName"');
+  }
+
+  @override
+  void addIndex(String name, List<String> columns, IndexType type) {
+    String indexType = '';
+
+    switch (type) {
+      case IndexType.primaryKey:
+        indexType = 'PRIMARY KEY';
+        break;
+      case IndexType.unique:
+        indexType = 'CONSTRAINT "$name" UNIQUE';
+        break;
+      case IndexType.standardIndex:
+      case IndexType.none:
+        // not working with postgres
+        return;
+    }
+
+    // mask the column names, is more safety
+    columns.map((column) => '"$column"');
+
+    _stack.add('ADD $indexType (${columns.join(',')})');
+  }
+
+  @override
+  void dropIndex(String name) {
+    _stack.add('DROP CONSTRAINT "$name"');
+  }
+
+  @override
+  void dropPrimaryIndex() {
+    _stack.add('DROP CONSTRAINT "${tableName}_pkey"');
   }
 }


### PR DESCRIPTION
Hi, i have add the methods  `addIndex`, `dropIndex`, and `dropPrimaryIndex` for alter table statements

it works completely for MySQL and MariaDB and partial for PostgreSQL, in Postgres you can use only add/drop primary key and add/drop unique constraint in a alter table

i'm work also on a extra method to add/drop indexes without alter table, but i'm not shure i can finishing it this week