### PR TITLE
add a way to change indexes with migrations without alter table

### DIFF
--- a/packages/orm/angel_migration/lib/src/schema.dart
+++ b/packages/orm/angel_migration/lib/src/schema.dart
@@ -14,4 +14,9 @@ abstract class Schema {
   void createIfNotExists(String tableName, void Function(Table table) callback);
 
   void alter(String tableName, void Function(MutableTable table) callback);
+
+  void indexes(
+    String tableName,
+    void Function(MutableIndexes indexes) callback,
+  );
 }

--- a/packages/orm/angel_migration/lib/src/table.dart
+++ b/packages/orm/angel_migration/lib/src/table.dart
@@ -43,14 +43,24 @@ abstract class Table {
   }
 }
 
-abstract class MutableTable extends Table {
+abstract class MutableTable extends Table implements MutableIndexes {
   void rename(String newName);
+
   void dropColumn(String name);
+
   void renameColumn(String name, String newName);
+
   void changeColumnType(String name, ColumnType type);
+
   void dropNotNull(String name);
+
   void setNotNull(String name);
+}
+
+abstract class MutableIndexes {
   void addIndex(String name, List<String> columns, IndexType type);
+
   void dropIndex(String name);
+
   void dropPrimaryIndex();
 }

--- a/packages/orm/angel_migration_runner/lib/src/mariadb/schema.dart
+++ b/packages/orm/angel_migration_runner/lib/src/mariadb/schema.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:angel3_migration/angel3_migration.dart';
 import 'package:logging/logging.dart';
 import 'package:mysql1/mysql1.dart';
@@ -74,4 +75,12 @@ class MariaDbSchema extends Schema {
   void createIfNotExists(
           String tableName, void Function(Table table) callback) =>
       _create(tableName, callback, true);
+
+  @override
+  void indexes(String tableName, void Function(MutableIndexes index) callback) {
+    var tbl = MariaDbIndexes(tableName);
+    callback(tbl);
+
+    tbl.compile(_buf);
+  }
 }

--- a/packages/orm/angel_migration_runner/lib/src/mysql/schema.dart
+++ b/packages/orm/angel_migration_runner/lib/src/mysql/schema.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:angel3_migration/angel3_migration.dart';
 import 'package:logging/logging.dart';
 import 'package:mysql_client/mysql_client.dart';
@@ -79,4 +80,12 @@ class MySqlSchema extends Schema {
   void createIfNotExists(
           String tableName, void Function(Table table) callback) =>
       _create(tableName, callback, true);
+
+  @override
+  void indexes(String tableName, void Function(MutableIndexes table) callback) {
+    var tbl = MysqlIndexes(tableName);
+    callback(tbl);
+
+    tbl.compile(_buf);
+  }
 }

--- a/packages/orm/angel_migration_runner/lib/src/mysql/table.dart
+++ b/packages/orm/angel_migration_runner/lib/src/mysql/table.dart
@@ -235,3 +235,52 @@ class MysqlAlterTable extends Table implements MutableTable {
     _stack.add('DROP PRIMARY KEY');
   }
 }
+
+class MysqlIndexes implements MutableIndexes {
+  final String tableName;
+  final Queue<String> _stack = Queue<String>();
+
+  MysqlIndexes(this.tableName);
+
+  void compile(StringBuffer buf) {
+    while (_stack.isNotEmpty) {
+      buf.writeln(_stack.removeFirst());
+    }
+  }
+
+  @override
+  void addIndex(String name, List<String> columns, IndexType type) {
+    // mask the column names, is more safety
+    columns.map((column) => '`$column`');
+
+    switch (type) {
+      case IndexType.primaryKey:
+        _stack.add(
+          'ALTER TABLE `$tableName` ADD PRIMARY KEY (${columns.join(',')});',
+        );
+        break;
+      case IndexType.unique:
+        _stack.add(
+          'CREATE UNIQUE INDEX `$name` ON `$tableName` (${columns.join(',')});',
+        );
+        break;
+      case IndexType.standardIndex:
+      case IndexType.none:
+      default:
+        _stack.add(
+          'CREATE INDEX `$name` ON `$tableName` (${columns.join(',')});',
+        );
+        break;
+    }
+  }
+
+  @override
+  void dropIndex(String name) {
+    _stack.add('DROP INDEX `$name` ON `$tableName`;');
+  }
+
+  @override
+  void dropPrimaryIndex() {
+    _stack.add('DROP INDEX `PRIMARY` ON `$tableName`;');
+  }
+}

--- a/packages/orm/angel_migration_runner/lib/src/postgres/schema.dart
+++ b/packages/orm/angel_migration_runner/lib/src/postgres/schema.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+
 import 'package:angel3_migration/angel3_migration.dart';
-import 'package:postgres/postgres.dart';
 import 'package:logging/logging.dart';
+import 'package:postgres/postgres.dart';
+
 import 'table.dart';
 
 /// A PostgreSQL database schema generator
@@ -73,4 +75,12 @@ class PostgresSchema extends Schema {
   void createIfNotExists(
           String tableName, void Function(Table table) callback) =>
       _create(tableName, callback, true);
+
+  @override
+  void indexes(String tableName, void Function(MutableIndexes table) callback) {
+    var tbl = PostgresIndexes(tableName);
+    callback(tbl);
+
+    tbl.compile(_buf);
+  }
 }

--- a/packages/orm/angel_migration_runner/lib/src/postgres/table.dart
+++ b/packages/orm/angel_migration_runner/lib/src/postgres/table.dart
@@ -176,7 +176,6 @@ class PostgresAlterTable extends Table implements MutableTable {
         indexType = 'PRIMARY KEY';
         break;
       case IndexType.unique:
-        // ??
         indexType = 'CONSTRAINT "$name" UNIQUE';
         break;
       case IndexType.standardIndex:


### PR DESCRIPTION
hi, here is a index update for the migrations working for MySQL, MariaDB, and PostgreSQL

the methods for the index migration is `addIndex`, `dropIndex`, and `dropPrimaryIndex`

here is a example
```
class UserTodoMigration5 extends Migration {
  @override
  void up(Schema schema) {
    schema.indexes('user_todo', (table) {
      table.dropIndex('user_id_index');
    });
  }

  @override
  void down(Schema schema) {
    schema.indexes('user_todo', (table) {
      table.addIndex('user_id_index', ['user_id'], IndexType.standardIndex);
    });
  }
}
```

